### PR TITLE
feat: upload server sourcemaps to Sentry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@
 
 ## 에러 모니터링 (Sentry)
 
-Sentry 프로젝트: `panda-1r/jihoon-blog` (`@sentry/nextjs`)
+Sentry 프로젝트: `hooninedev/jihoon-blog` (`@sentry/nextjs`)
 
 ### 서버 전용 구성이다
 
@@ -114,8 +114,19 @@ Sentry 프로젝트: `panda-1r/jihoon-blog` (`@sentry/nextjs`)
 
 - 로컬: `.env` 의 `NEXT_PUBLIC_SENTRY_DSN`
 - Netlify 대시보드에도 `NEXT_PUBLIC_SENTRY_DSN` 을 등록해야 한다. `.env*` 는 gitignore 대상이라 배포 환경엔 자동으로 넘어가지 않는다.
-- 소스맵 업로드를 쓰려면 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` 를 추가한다. 토큰이 없으면 업로드만 꺼지고 빌드는 통과한다. (`next.config.ts` 의 `sourcemaps.disable`)
-- `SENTRY_ORG` 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다.
+- 소스맵 업로드에는 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` 가 필요하다. Netlify 대시보드에 등록되어 있다. 토큰이 없으면 업로드만 꺼지고 빌드는 통과한다. (`next.config.ts` 의 `sourcemaps.disable`)
+- `SENTRY_ORG` 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다. 현재 슬러그는 `hooninedev` 다.
+- 토큰은 organization auth token 이고 스코프는 `project:releases` 다.
+
+### 소스맵
+
+Turbopack 빌드도 업로드를 지원한다. `useRunAfterProductionCompileHook` 이 Turbopack 에서 기본 `true` 이고, 빌드 로그의 `Running next.config.js provided runAfterProductionCompile` 이 그 경로다. 서버 `.map` 은 Next 가 이미 130개 남짓 생성하므로 따로 켤 설정은 없다.
+
+`deleteSourcemapsAfterUpload` 를 켠 이유는 용량이다. Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 큰데, 지우지 않으면 그게 전부 Netlify 함수 번들에 실린다. 업로드 후에는 필요 없다.
+
+`silent` 은 조건부다. 항상 켜두면 토큰 스코프 부족이나 만료로 업로드가 실패해도 조용히 넘어가서, 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없다. 업로드를 시도할 때만 로그를 남긴다.
+
+**클라이언트 맵은 대상이 아니다.** 서버 전용 구성이라 브라우저 SDK 가 없다.
 
 ### 동작 조건과 정책
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,14 +19,28 @@ const nextConfig: NextConfig = {
   },
 };
 
+const hasSentryAuthToken = Boolean(process.env.SENTRY_AUTH_TOKEN);
+
 export default withSentryConfig(withContentlayer(nextConfig), {
+  // org 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다.
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
-  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+  sourcemaps: {
+    // 토큰이 없으면 업로드를 아예 끈다. 토큰 없이 시도하다 빌드가 깨지면 배포가 막힌다.
+    disable: !hasSentryAuthToken,
 
-  silent: true,
+    // 업로드가 끝나면 빌드 산출물에서 .map 을 지운다.
+    // Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 크고,
+    // 그대로 두면 Netlify 함수 번들에 전부 실린다. 업로드 후에는 쓸모가 없다.
+    deleteSourcemapsAfterUpload: hasSentryAuthToken,
+  },
+
+  // 업로드를 시도할 때만 로그를 남긴다.
+  // silent 를 항상 켜두면 토큰 스코프 부족·만료로 업로드가 실패해도 조용히 넘어가,
+  // 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없다.
+  silent: !hasSentryAuthToken,
   telemetry: false,
 
   bundleSizeOptimizations: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,13 @@ export default withSentryConfig(withContentlayer(nextConfig), {
     // 업로드가 끝나면 빌드 산출물에서 .map 을 지운다.
     // Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 크고,
     // 그대로 두면 Netlify 함수 번들에 전부 실린다. 업로드 후에는 쓸모가 없다.
-    deleteSourcemapsAfterUpload: hasSentryAuthToken,
+    //
+    // deleteSourcemapsAfterUpload 만으로는 `.next/static` 만 지워지고
+    // 정작 용량을 차지하는 `.next/server` 는 남는다. 실측으로 확인했다.
+    // 그래서 glob 을 직접 지정한다.
+    filesToDeleteAfterUpload: hasSentryAuthToken
+      ? [".next/server/**/*.map", ".next/static/**/*.map"]
+      : [],
   },
 
   // 업로드를 시도할 때만 로그를 남긴다.


### PR DESCRIPTION
프로덕션 스택 트레이스가 난독화 상태였습니다. Netlify 검증(PR #14)에서 잡힌 이벤트의 culprit 이 `y([root-of-the-server]__468aa3ae._)` 로 찍혔습니다.

## Turbopack 에서도 동작한다

SDK 타입 문서의 "For Turbopack no sourcemaps will be uploaded" 는 `useRunAfterProductionCompileHook: false` 인 경우 얘기고, **Turbopack 에서는 이 옵션이 기본 `true`** 입니다. 빌드 로그의 `Running next.config.js provided runAfterProductionCompile` 이 그 경로입니다. 서버 `.map` 은 Next 가 이미 131개 생성하고 있어 따로 켤 설정은 없습니다.

## deleteSourcemapsAfterUpload 를 켠 이유

용량입니다. Turbopack 이 만드는 서버 소스맵이 **57MB** 로 서버 JS(15MB) 보다 큰데, 지우지 않으면 전부 Netlify 함수 번들에 실립니다. 업로드 후에는 필요 없으니 지우면 함수가 오히려 가벼워집니다.

## silent 를 조건부로 바꿈

항상 켜두면 토큰 스코프 부족이나 만료로 업로드가 실패해도 조용히 넘어가, 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없습니다. 업로드를 시도할 때만 로그를 남깁니다.

## 검증

- 토큰 없는 빌드에서 exit 0, 맵 유지, 서버 훅 정상 (graceful 경로)
- **읽을 수 있는 스택 프레임 확인은 별도 검증 PR 의 Deploy Preview 로 진행 중.** 그게 통과하기 전에는 머지하지 않습니다. 빌드 로그의 "업로드 완료" 와 "Sentry 가 실제로 심볼라이즈한다" 는 다른 주장입니다.

org 슬러그는 `panda-1r` 에서 `hooninedev` 로 변경됐고 문서에 반영했습니다.