### PR TITLE
chore: [DO NOT MERGE] verify sourcemap symbolication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@
 
 ## 에러 모니터링 (Sentry)
 
-Sentry 프로젝트: `panda-1r/jihoon-blog` (`@sentry/nextjs`)
+Sentry 프로젝트: `hooninedev/jihoon-blog` (`@sentry/nextjs`)
 
 ### 서버 전용 구성이다
 
@@ -114,8 +114,19 @@ Sentry 프로젝트: `panda-1r/jihoon-blog` (`@sentry/nextjs`)
 
 - 로컬: `.env` 의 `NEXT_PUBLIC_SENTRY_DSN`
 - Netlify 대시보드에도 `NEXT_PUBLIC_SENTRY_DSN` 을 등록해야 한다. `.env*` 는 gitignore 대상이라 배포 환경엔 자동으로 넘어가지 않는다.
-- 소스맵 업로드를 쓰려면 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` 를 추가한다. 토큰이 없으면 업로드만 꺼지고 빌드는 통과한다. (`next.config.ts` 의 `sourcemaps.disable`)
-- `SENTRY_ORG` 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다.
+- 소스맵 업로드에는 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` 가 필요하다. Netlify 대시보드에 등록되어 있다. 토큰이 없으면 업로드만 꺼지고 빌드는 통과한다. (`next.config.ts` 의 `sourcemaps.disable`)
+- `SENTRY_ORG` 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다. 현재 슬러그는 `hooninedev` 다.
+- 토큰은 organization auth token 이고 스코프는 `project:releases` 다.
+
+### 소스맵
+
+Turbopack 빌드도 업로드를 지원한다. `useRunAfterProductionCompileHook` 이 Turbopack 에서 기본 `true` 이고, 빌드 로그의 `Running next.config.js provided runAfterProductionCompile` 이 그 경로다. 서버 `.map` 은 Next 가 이미 130개 남짓 생성하므로 따로 켤 설정은 없다.
+
+`deleteSourcemapsAfterUpload` 를 켠 이유는 용량이다. Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 큰데, 지우지 않으면 그게 전부 Netlify 함수 번들에 실린다. 업로드 후에는 필요 없다.
+
+`silent` 은 조건부다. 항상 켜두면 토큰 스코프 부족이나 만료로 업로드가 실패해도 조용히 넘어가서, 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없다. 업로드를 시도할 때만 로그를 남긴다.
+
+**클라이언트 맵은 대상이 아니다.** 서버 전용 구성이라 브라우저 SDK 가 없다.
 
 ### 동작 조건과 정책
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -19,14 +19,28 @@ const nextConfig: NextConfig = {
   },
 };
 
+const hasSentryAuthToken = Boolean(process.env.SENTRY_AUTH_TOKEN);
+
 export default withSentryConfig(withContentlayer(nextConfig), {
+  // org 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다.
   org: process.env.SENTRY_ORG,
   project: process.env.SENTRY_PROJECT,
   authToken: process.env.SENTRY_AUTH_TOKEN,
 
-  sourcemaps: { disable: !process.env.SENTRY_AUTH_TOKEN },
+  sourcemaps: {
+    // 토큰이 없으면 업로드를 아예 끈다. 토큰 없이 시도하다 빌드가 깨지면 배포가 막힌다.
+    disable: !hasSentryAuthToken,
 
-  silent: true,
+    // 업로드가 끝나면 빌드 산출물에서 .map 을 지운다.
+    // Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 크고,
+    // 그대로 두면 Netlify 함수 번들에 전부 실린다. 업로드 후에는 쓸모가 없다.
+    deleteSourcemapsAfterUpload: hasSentryAuthToken,
+  },
+
+  // 업로드를 시도할 때만 로그를 남긴다.
+  // silent 를 항상 켜두면 토큰 스코프 부족·만료로 업로드가 실패해도 조용히 넘어가,
+  // 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없다.
+  silent: !hasSentryAuthToken,
   telemetry: false,
 
   bundleSizeOptimizations: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,13 @@ export default withSentryConfig(withContentlayer(nextConfig), {
     // 업로드가 끝나면 빌드 산출물에서 .map 을 지운다.
     // Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 크고,
     // 그대로 두면 Netlify 함수 번들에 전부 실린다. 업로드 후에는 쓸모가 없다.
-    deleteSourcemapsAfterUpload: hasSentryAuthToken,
+    //
+    // deleteSourcemapsAfterUpload 만으로는 `.next/static` 만 지워지고
+    // 정작 용량을 차지하는 `.next/server` 는 남는다. 실측으로 확인했다.
+    // 그래서 glob 을 직접 지정한다.
+    filesToDeleteAfterUpload: hasSentryAuthToken
+      ? [".next/server/**/*.map", ".next/static/**/*.map"]
+      : [],
   },
 
   // 업로드를 시도할 때만 로그를 남긴다.

--- a/src/app/api/sentry-check/route.ts
+++ b/src/app/api/sentry-check/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from "next/server";
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * 임시 검증용 라우트. 소스맵 업로드 후 스택 트레이스가 읽히는지 확인한다.
+ *
+ * Deploy Preview 에서만 사용하고 main 에 머지하지 않는다.
+ *
+ * 판정 기준은 빌드 로그의 "업로드 완료" 가 아니라 Sentry 이벤트의 프레임이다.
+ * 업로드 전에는 culprit 이 y([root-of-the-server]__468aa3ae._) 처럼 찍혔다.
+ * 이 파일 경로와 줄번호로 바뀌어야 통과다.
+ */
+export async function GET(request: NextRequest) {
+  const params = new URL(request.url).searchParams;
+  const mode = params.get("mode") ?? "explicit";
+  const stamp = params.get("stamp") ?? "no-stamp";
+
+  if (mode === "throw") {
+    throw new Error(`sourcemap-check throw path (${stamp})`);
+  }
+
+  const error = new Error(`sourcemap-check explicit path (${stamp})`);
+  Sentry.captureException(error, {
+    tags: { verification: "sourcemaps", mode, stamp },
+  });
+  await Sentry.flush(5000);
+
+  return NextResponse.json({ mode, stamp });
+}


### PR DESCRIPTION
PR #15 의 소스맵 업로드 설정이 실제로 **읽을 수 있는 스택 프레임**을 만드는지 Deploy Preview 로 검증하기 위한 임시 PR입니다. 머지하지 않고 닫습니다.

업로드 전 culprit: `y([root-of-the-server]__468aa3ae._)`
통과 기준: `src/app/api/sentry-check/route.ts` + 줄번호로 해석

`/api/sentry-check?mode=explicit|throw` 두 경로로 확인합니다.