### PR TITLE
docs: correct sourcemap option and auth token type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,17 +116,28 @@ Sentry 프로젝트: `hooninedev/jihoon-blog` (`@sentry/nextjs`)
 - Netlify 대시보드에도 `NEXT_PUBLIC_SENTRY_DSN` 을 등록해야 한다. `.env*` 는 gitignore 대상이라 배포 환경엔 자동으로 넘어가지 않는다.
 - 소스맵 업로드에는 `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` 가 필요하다. Netlify 대시보드에 등록되어 있다. 토큰이 없으면 업로드만 꺼지고 빌드는 통과한다. (`next.config.ts` 의 `sourcemaps.disable`)
 - `SENTRY_ORG` 는 슬러그 기준이다. Sentry org 슬러그를 바꾸면 이 값도 같이 바꿔야 업로드가 동작한다. 현재 슬러그는 `hooninedev` 다.
-- 토큰은 organization auth token 이고 스코프는 `project:releases` 다.
+- 토큰 스코프는 `project:releases` 다. 현재 쓰는 토큰은 `sntryu_` 로 시작하는 **user(개인) 토큰**이다. 동작은 하지만 계정 변경에 취약하므로 `sntrys_` organization 토큰으로 교체하는 편이 낫다.
 
 ### 소스맵
 
 Turbopack 빌드도 업로드를 지원한다. `useRunAfterProductionCompileHook` 이 Turbopack 에서 기본 `true` 이고, 빌드 로그의 `Running next.config.js provided runAfterProductionCompile` 이 그 경로다. 서버 `.map` 은 Next 가 이미 130개 남짓 생성하므로 따로 켤 설정은 없다.
 
-`deleteSourcemapsAfterUpload` 를 켠 이유는 용량이다. Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 큰데, 지우지 않으면 그게 전부 Netlify 함수 번들에 실린다. 업로드 후에는 필요 없다.
+업로드 후 `.map` 을 지우는 이유는 용량이다. Turbopack 이 만드는 서버 소스맵이 57MB 로 서버 JS(15MB) 보다 큰데, 지우지 않으면 그게 전부 Netlify 함수 번들에 실린다. 업로드 후에는 필요 없다.
+
+**여기서 `deleteSourcemapsAfterUpload: true` 는 쓰지 않는다.** 그 옵션은 `.next/static` 만 지우고 정작 용량을 차지하는 `.next/server` 는 남긴다. 실측으로 확인했다(업로드 직후에도 서버 `.map` 135개 / 57MB 잔존). 그래서 `filesToDeleteAfterUpload` 로 `.next/server/**/*.map` 과 `.next/static/**/*.map` 을 직접 지정한다.
 
 `silent` 은 조건부다. 항상 켜두면 토큰 스코프 부족이나 만료로 업로드가 실패해도 조용히 넘어가서, 다음에 읽을 수 없는 스택 트레이스를 볼 때까지 알 수 없다. 업로드를 시도할 때만 로그를 남긴다.
 
 **클라이언트 맵은 대상이 아니다.** 서버 전용 구성이라 브라우저 SDK 가 없다.
+
+### 검증 완료 상태 (2026-08-04)
+
+Netlify 함수 런타임에서 실제 이벤트로 확인한 것들이다. Deploy Preview 에 임시 라우트를 올려 검증하고 머지하지 않고 닫는 방식을 썼다. 프로덕션 크레덴셜을 건드리지 않아도 된다.
+
+- 서버 캡처: `captureException` 이 `flush()` 없이도 전송된다. 서버리스에서 응답 후 함수가 얼어 전송이 끊길까 걱정했지만 문제 없었다. `google-analytics.ts` 가 쓰는 경로가 이것이다.
+- `onRequestError` 자동 훅: 핸들링하지 않은 라우트 에러도 잡힌다 (`mechanism: auto.function.nextjs.on_request_error`).
+- 소스맵: 스택이 `src/...` 경로 + 줄번호 + 주변 소스 코드까지 해석된다. 적용 전에는 `y([root-of-the-server]__468aa3ae._)` 였다.
+- 이벤트 지연: throw 경로 이벤트가 약 2분 늦게 도착한 적이 있다. 즉시 조회해서 없다고 누락으로 판단하면 안 된다.
 
 ### 동작 조건과 정책
 


### PR DESCRIPTION
CLAUDE.md 두 군데가 실제 코드/설정과 달랐습니다.

1. `deleteSourcemapsAfterUpload` 를 켰다고 서술했으나 실제로는 `filesToDeleteAfterUpload` 를 씁니다. 전자가 `.next/server` 를 남기는 문제 때문에 바꿨는데 문서를 같이 고치지 않았습니다.
2. 토큰을 organization auth token 이라고 단정했으나 실제로는 `sntryu_` 로 시작하는 user 토큰입니다.

Netlify 런타임에서 실제 이벤트로 검증한 항목(flush 없는 전송, onRequestError, 소스맵 해석, 이벤트 지연)도 기록합니다.