### PR TITLE
fix: bound GA Data API calls with a 5 second timeout (JIHOON-BLOG-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Netlify 함수 런타임에서 실제 이벤트로 확인한 것들이다. Deplo
 - DSN 이 있고 `NODE_ENV === 'production'` 일 때만 전송한다. 개발 중 발생하는 에러는 무료 티어 쿼터만 태우므로 보내지 않는다.
 - `tracesSampleRate` 는 0.1. Core Web Vitals 는 기존대로 `WebVitalsReporter` 가 GA4 로 보내고, Sentry 는 에러와 낮은 샘플링 트레이싱만 담당한다.
 - **Session Replay 는 쓰지 않는다.** 블로그는 로딩 성능이 곧 SEO 라서 비용이 이득보다 크다. `next.config.ts` 의 `bundleSizeOptimizations` 로 관련 코드를 번들에서 제거한다.
+- **GA 호출에는 반드시 `gaCallOptions()` 를 넘긴다.** `src/lib/ga-request-options.ts` 에 있다. `runReport` 의 라이브러리 기본 RPC 타임아웃이 60초여서, 넘기지 않으면 GA 가 응답하지 않을 때 요청이 60초 넘게 매달린다. fallback 때문에 응답은 200 이라 조용히 통계만 빈다. 프로덕션에서 `Deadline exceeded after 65.877s` 로 실제 관측됐다(JIHOON-BLOG-2). 블랙홀 서버로 재현해 타임아웃 미지정 60.04초 / 5초 지정 5.00초를 실측했다. `src/lib/ga-request-options.test.mjs` 가 호출 지점 누락을 막는다.
 - `src/lib/google-analytics.ts` 의 catch 블록 4곳에서 `captureException` 을 호출한다. 이 함수들은 GA 호출이 실패해도 fallback 값을 반환하고 응답은 200 이라, 계측하지 않으면 통계가 0 으로 보이는 장애를 알 방법이 없다. **라우트 핸들러의 catch 만으로는 잡히지 않는다.** 실제로 검증 과정에서 이 사실이 드러났다.
 
 ### 번들 비용 실측 (2026-08-04)

--- a/src/lib/ga-request-options.test.mjs
+++ b/src/lib/ga-request-options.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { GA_REQUEST_TIMEOUT_MS, gaCallOptions } from "./ga-request-options.ts";
+
+/**
+ * JIHOON-BLOG-2 회귀 방지.
+ *
+ * GA Data API 의 runReport 는 라이브러리 기본 RPC 타임아웃이 60초다.
+ * (@google-analytics/data 의 beta_analytics_data_client_config.json)
+ * 호출 지점에서 타임아웃을 넘기지 않으면 GA 가 응답하지 않을 때 요청이
+ * 60초 넘게 매달리고, catch 의 fallback 때문에 응답은 200 으로 나간다.
+ * 프로덕션에서 "Deadline exceeded after 65.877s" 로 관측됐다.
+ */
+
+test("bounds GA calls well below the library's 60 second default", () => {
+  assert.equal(typeof GA_REQUEST_TIMEOUT_MS, "number");
+  assert.ok(
+    GA_REQUEST_TIMEOUT_MS > 0,
+    "타임아웃이 0 이하면 호출이 즉시 실패한다",
+  );
+  assert.ok(
+    GA_REQUEST_TIMEOUT_MS <= 10_000,
+    `방문자를 기다리게 하지 않으려면 10초 이하여야 한다 (현재 ${GA_REQUEST_TIMEOUT_MS}ms)`,
+  );
+});
+
+test("passes the timeout as gax CallOptions", () => {
+  assert.deepEqual(gaCallOptions(), { timeout: GA_REQUEST_TIMEOUT_MS });
+});
+
+test("every runReport call in google-analytics.ts uses the shared options", () => {
+  const source = readFileSync(
+    new URL("./google-analytics.ts", import.meta.url),
+    "utf8",
+  );
+
+  const callCount = source.match(/\.runReport\(/g)?.length ?? 0;
+  const optionCount = source.match(/gaCallOptions\(\)/g)?.length ?? 0;
+
+  assert.ok(callCount > 0, "runReport 호출을 찾지 못했다");
+  assert.equal(
+    optionCount,
+    callCount,
+    `runReport ${callCount}개 중 ${optionCount}개만 타임아웃을 넘긴다`,
+  );
+});

--- a/src/lib/ga-request-options.ts
+++ b/src/lib/ga-request-options.ts
@@ -1,0 +1,23 @@
+/**
+ * GA Data API 호출에 공통으로 적용하는 gax CallOptions.
+ *
+ * `@google-analytics/data` 의 runReport 는 라이브러리 기본 RPC 타임아웃이
+ * 60초다. (beta_analytics_data_client_config.json 의 `timeout_millis: 60000`)
+ * 호출 지점에서 타임아웃을 넘기지 않으면 GA 가 응답하지 않을 때 요청이
+ * 60초 넘게 매달린다. 프로덕션에서 "Deadline exceeded after 65.877s" 로
+ * 관측됐고, catch 의 fallback 때문에 응답은 200 이라 조용히 통계만 비었다.
+ *
+ * 이 블로그에서 GA 수치는 부가 정보다. 정확히 받는 것보다 빠르게 포기하고
+ * fallback 을 렌더하는 편이 방문자 경험에 낫다.
+ *
+ * Next 에 의존하지 않는 별도 모듈로 둔 이유는 테스트다.
+ * google-analytics.ts 는 `next/cache` 를 import 해서 `node --test` 로
+ * 불러올 수 없다.
+ */
+
+/** GA 호출 하나가 기다릴 수 있는 최대 시간. */
+export const GA_REQUEST_TIMEOUT_MS = 5_000;
+
+export function gaCallOptions(): { timeout: number } {
+  return { timeout: GA_REQUEST_TIMEOUT_MS };
+}

--- a/src/lib/google-analytics.ts
+++ b/src/lib/google-analytics.ts
@@ -3,6 +3,7 @@ import { unstable_cache } from "next/cache";
 import * as Sentry from "@sentry/nextjs";
 
 import { addDailyVisitorBaseline } from "@/lib/daily-visitor-baseline";
+import { gaCallOptions } from "@/lib/ga-request-options";
 
 const propertyId = process.env.GA_PROPERTY_ID;
 const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
@@ -68,7 +69,7 @@ async function fetchAnalyticsStats(): Promise<AnalyticsStats> {
             },
           },
         },
-      }),
+      }, gaCallOptions()),
       client.runReport({
         property: `properties/${propertyId}`,
         dateRanges: [{ startDate: "today", endDate: "today" }],
@@ -82,7 +83,7 @@ async function fetchAnalyticsStats(): Promise<AnalyticsStats> {
             },
           },
         },
-      }),
+      }, gaCallOptions()),
     ]);
 
     const totalPageViews = parseInt(
@@ -142,7 +143,7 @@ async function fetchPopularPages(limit: number = 10): Promise<PopularPage[]> {
       metrics: [{ name: "screenPageViews" }],
       orderBys: [{ metric: { metricName: "screenPageViews" }, desc: true }],
       limit,
-    });
+    }, gaCallOptions());
 
     if (!response.rows) {
       return [];
@@ -203,7 +204,7 @@ export async function getPageViews(pagePath: string): Promise<number> {
           },
         },
       },
-    });
+    }, gaCallOptions());
 
     return parseInt(
       response.rows?.[0]?.metricValues?.[0]?.value || "0",
@@ -246,7 +247,7 @@ export async function getMultiplePageViews(
           })),
         },
       },
-    });
+    }, gaCallOptions());
 
     const result: Record<string, number> = {};
     response.rows?.forEach((row) => {


### PR DESCRIPTION
Sentry 가 잡은 첫 실제 프로덕션 장애입니다. `JIHOON-BLOG-2`.

## 증상

GA 호출이 **65.877초** 후 `DEADLINE_EXCEEDED` 로 실패합니다. catch 가 fallback 을 반환하므로 응답은 200 이고, 방문자에게는 통계가 조용히 빈 상태로 보입니다. 그 전에 최대 1분 넘게 매달립니다. 홈은 dynamic 렌더라 이 대기가 그대로 노출됩니다.

`gaQuery` 태그 분포는 `stats` 3건 + `popular` 3건으로, 특정 쿼리만의 문제가 아닙니다.

## 근본 원인

`@google-analytics/data` 의 `beta_analytics_data_client_config.json`:

```json
"RunReport": { "timeout_millis": 60000, "retry_params_name": "default" }
"default":   { "initial_rpc_timeout_millis": 60000, "max_rpc_timeout_millis": 60000 }
```

라이브러리 기본 RPC 타임아웃이 60초인데 우리 코드는 5개 호출 지점 어디에도 gax `CallOptions` 를 넘기지 않았습니다. 관측된 65.877초 = 60초 + 연결/LB 오버헤드입니다.

## 실측

응답하지 않는 로컬 TCP 서버로 결정적 재현:

| 조건 | 경과 | 에러 |
|---|---|---|
| 타임아웃 미지정 (수정 전) | **60.04초** | `Deadline exceeded after 60.000s` |
| `timeout: 5000` (수정 후) | **5.00초** | `Deadline exceeded after 5.000s` |

## 수정

`src/lib/ga-request-options.ts` 에 `GA_REQUEST_TIMEOUT_MS = 5000` 과 `gaCallOptions()` 를 두고 5개 호출 지점 전부에 넘깁니다.

Next 에 의존하지 않는 별도 모듈로 뺀 이유는 테스트입니다. `google-analytics.ts` 는 `next/cache` 를 import 해서 `node --test` 로 불러올 수 없습니다.

이 블로그에서 GA 수치는 부가 정보이므로, 정확히 받는 것보다 빠르게 포기하고 fallback 을 렌더하는 편이 낫다는 판단입니다.

## 테스트

`src/lib/ga-request-options.test.mjs` 3개. 수정 전 `runReport 5개 중 0개만 타임아웃을 넘긴다` 로 실패하는 것을 확인한 뒤 구현했습니다. 8/8 통과, 빌드 exit 0, lint clean.